### PR TITLE
Add mtrl-icon Element to the List

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A curated list of custom-elements written in vanilla javascript
 | <pre>fun-router</pre> | Express.js inspired client side router | <pre>npm i fun-router</pre> | [kiricon/fun-router](https://github.com/Kiricon/fun-router)|
 | <pre>fun-tabs</pre> | Animated, styled tabs | <pre>npm i fun-tabs</pre> | [kiricon/fun-tabs](https://github.com/Kiricon/fun-tabs)|
 | <pre>lazy-img</pre> | Loads image only when in the viewport | <pre>npm i lazy-img-element</pre> | [aeolingamenfel/lazy-img](https://github.com/aeolingamenfel/lazy-img) |
+| <pre>mtrl-icon</pre> | Material icon | <pre>npm i mtrl-icon</pre> | [aeolingamenfel/mtrl-icon](https://github.com/aeolingamenfel/mtrl-icon) |
 | <pre>side-nav</pre> | A pop out side nav/shelf | <pre>npm i side-nav</pre> | [kiricon/side-nav](https://github.com/Kiricon/side-nav)|
 | <pre>text-input-button</pre> | Button attached text input | <pre>npm i text-input-button</pre> | [kiricon/text-input-button](https://github.com/Kiricon/text-input-button)|
 | <pre>top-nav</pre> | Fixed position, 100% width top nav bar | <pre>npm i top-nav</pre> | [kiricon/top-nav](https://github.com/Kiricon/top-nav) |


### PR DESCRIPTION
Just like the title says. Adds my `<mtrl-icon>` element to the list. See the repo for more information. 